### PR TITLE
Fix HeaderTest.h incorrect memset invocation

### DIFF
--- a/unittest/HeaderTest.h
+++ b/unittest/HeaderTest.h
@@ -9,7 +9,7 @@ TEST_CASE( "boeHeader.headerEncode" ) {
 	boeHeader.mid = 3;
         boeHeader.uid = 10; 
 	char *s = (char *)malloc(100 * sizeof(char));
-        memset(s, 100, '\0');
+        memset(s, '\0', 100);
 	boeHeader.headerEncode(s);
         int64_t encode_num;
         int8_t *encode_p = (int8_t *)&encode_num;
@@ -28,7 +28,7 @@ TEST_CASE( "boeHeader.headerDecode" ) {
 	boeHeader.mid = 3;
         boeHeader.uid = 10; 
 	char *s = (char *)malloc(100 * sizeof(char));
-        memset(s, 100, '\0');
+        memset(s, '\0', 100);
         s[0] = 1;
         s[1] = 5;
         s[2] = 1;


### PR DESCRIPTION
The `void *memset(void *s, int c, size_t n)` function takes the value to fill in its 2nd argument and the number of byte to fill in in 3rd.

This commit fixes an invalid use of `memset` which had the two arguments swapped and it did not set any memory at all in the end due to that.